### PR TITLE
Change links from docs.bitshares.eu to docs.bitshares.org

### DIFF
--- a/_content/en/download.md
+++ b/_content/en/download.md
@@ -15,7 +15,7 @@ Please see the [registration tutorial](/register/){:target="_blank"} if you are 
 - Modern Internet Browser
 
 ## Documentation
-Documentation is available at [docs.bitshares.eu](http://docs.bitshares.eu/){:target="_blank"}.
+Documentation is available at [docs.bitshares.org](http://docs.bitshares.org/){:target="_blank"}.
 
 ## Technical Support
 Technical support is available in the community [Technical Support subforum](https://bitsharestalk.org/index.php/board,45.0.html){:target="_blank"}.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,8 +10,8 @@
        <ul>
          <li><a href="/technology/">Technology</a></li>
          <!-- <li><a href="/blog/">Blog</a></li> //-->
-         <li><a target="_blank" href="http://docs.bitshares.eu/">Documentation</a></li>
-         <li><a target="_blank" href="http://docs.bitshares.eu/migration/">Migration Guide</a></li>
+         <li><a target="_blank" href="http://docs.bitshares.org/">Documentation</a></li>
+         <li><a target="_blank" href="http://docs.bitshares.org/migration/">Migration Guide</a></li>
          <li><a target="_blank" href="http://cryptofresh.com/">Block Explorer</a></li>
          <li><a href="/contact/">Contact</a></li>
        </ul>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -16,7 +16,7 @@
                 <li class="active"><a href="/">Home</a></li>
             {% endif %}
             <li><a href="/technology/">Technology</a></li>
-            <li><a target="_blank" href="http://docs.bitshares.eu/">Documentation</a></li>
+            <li><a target="_blank" href="http://docs.bitshares.org/">Documentation</a></li>
             <li><a target="_blank" href="https://www.bitsharestalk.org">Forum</a></li>
             <li><a target="_blank" href="https://www.cryptofresh.com">Block Explorer</a></li>
             <li><a class="btn btn-primary" target="_blank" style="padding:4px 8px;margin-top: 10px" href="https://bitshares.org/wallet">Online Exchange</a></li>

--- a/roadmap.xml
+++ b/roadmap.xml
@@ -60,7 +60,7 @@
 						</link>
 						<link>
 							<label>website</label>
-							<url>http://docs.bitshares.eu/</url>
+							<url>http://docs.bitshares.org/</url>
 						</link>
 					</links>
 				</item>


### PR DESCRIPTION
I think we need to change these links. Because the site was moved to [bitshares.org](https://bitshares.org/) and documentation should point to the same domain. Especially if it's available there.