### PR TITLE
Remove link to non-existing page in price-stable-cryptocurrencies.md

### DIFF
--- a/_technologies/en/price-stable-cryptocurrencies.md
+++ b/_technologies/en/price-stable-cryptocurrencies.md
@@ -163,7 +163,7 @@ collateralized short position.  This is similar to an insolvent bank converting 
 
 Not every short seller will be happy with the rules offer by SmartCoins.  Some may want to borrow for a fixed period of time,
 with higher leverage, and with no risk of being force-settled.  BitShares offers these speculators the option to borrow
-BitUSD on the [bond market](/technology/collateralized-bond-market){:target="_blank"} at interest.   The bond market
+BitUSD on the bond market at interest.   The bond market
 allows speculators to leverage any asset against any other, while lenders earn interest on collateralized loans.   A
 Bond market is the perfect way for the market to establish a yield curve on SmartCoins and free both sides of the market
 from dependency on the price feed.


### PR DESCRIPTION
I'd love to read more about the bond market, but the page does not seem to exist. Ideal solution would probably be to create the page.

After some searching, it seems that perhaps the whole section should be removed?